### PR TITLE
Use virtual paths if enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ History
 1.0a6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use more beautiful paths if VirtualHostMonster is used.
+  [syzn]
 
 
 1.0a5 (2016-06-28)

--- a/src/zperfmetrics/__init__.py
+++ b/src/zperfmetrics/__init__.py
@@ -78,7 +78,13 @@ class ZMetric(Metric):
             stat = ''
             request = self._request
             if request:
-                stat += '.PATH.' + request['PATH_INFO']
+                path_info = request['PATH_INFO']
+                if 'VIRTUAL_URL_PARTS' in request and \
+                    request['VIRTUAL_URL_PARTS'] and \
+                    len(request['VIRTUAL_URL_PARTS']) > 1:
+                        path_info = request['VIRTUAL_URL_PARTS'][0]
+                        path_info = path_info.replace(".", "_")
+                stat = '.PATH.' + path_info
                 stat += '.' + statpart
             else:
                 stat = statpart
@@ -129,6 +135,13 @@ class ZMetric(Metric):
             buf = []
             request = self._request
             if request:
+                path_info = request['PATH_INFO']
+                if 'VIRTUAL_URL_PARTS' in request and \
+                    request['VIRTUAL_URL_PARTS'] and \
+                    len(request['VIRTUAL_URL_PARTS']) > 1:
+                        path_info = request['VIRTUAL_URL_PARTS'][0]
+                        path_info = path_info.replace(".", "_")
+                stat = '.PATH.' + path_info
                 stat = '.PATH.' + request['PATH_INFO']
                 stat += '.' + self.stat
             else:


### PR DESCRIPTION
Use the `VIRTUAL_URL_PARTS` instead of the `PATH_INFO` if the site is called via VirtualHostMonster (gives nice paths)
